### PR TITLE
Fix import statements

### DIFF
--- a/pyIcePAP/__init__.py
+++ b/pyIcePAP/__init__.py
@@ -15,10 +15,10 @@
 from .legacy import *
 from .communication import EthIcePAPCommunication
 from .controller import EthIcePAPController
-from .programming import *
+# from .programming import *
 from .fwversion import *
 from .utils import *
-from .backups import *
+# from .backups import *
 from .__main__ import get_parser
 
 # The version is updated automatically with bumpversion

--- a/pyIcePAP/__main__.py
+++ b/pyIcePAP/__main__.py
@@ -18,10 +18,10 @@ import logging.config
 import time
 import os
 import sys
-from .backups import IcePAPBackup, UNKNOWN
+from .backups import IcePAPBackup
 from .communication import EthIcePAPCommunication
 from .programming import firmware_update
-from .controller import EthIcePAPController
+
 
 LOGGING_CONFIG = {
     'version': 1,

--- a/pyIcePAP/backups.py
+++ b/pyIcePAP/backups.py
@@ -17,7 +17,7 @@ import configparser
 import time
 import logging
 import os
-from pyIcePAP import EthIcePAPController, Registers
+from pyIcePAP import EthIcePAPController
 
 
 KEYNOTFOUNDIN1 = 'KeyNotFoundInBackup'       # KeyNotFound for dictDiff


### PR DESCRIPTION
Fix imports to avoid unnecessary import of the
configparser when importing the library.