### PR TITLE
Protect connection to one IcePAP OFF

### DIFF
--- a/pyIcePAP/communication.py
+++ b/pyIcePAP/communication.py
@@ -262,7 +262,7 @@ class SocketCom(object):
 
     def _try_to_connect(self, wait=True):
         self._connected = False
-        sleep_time = self._timeout / 10
+        sleep_time = self._timeout / 10.0
         if self._socket is not None:
             try:
                 self._socket.close()

--- a/pyIcePAP/communication.py
+++ b/pyIcePAP/communication.py
@@ -212,7 +212,7 @@ class SocketCom(object):
         self._lock = Lock()
         self._stop_thread = False
         self._connect_thread = None
-        self._start_thread()
+        self._start_thread(wait=False)
         self._connect_thread.join()
 
     def __del__(self):
@@ -253,13 +253,14 @@ class SocketCom(object):
                                           str_maskedchksum, str_data)
         self._send_data(str_bin, wait_answer=False)
 
-    def _start_thread(self):
+    def _start_thread(self, wait=True):
         self.log.debug('Start thread {0}'.format(self._connect_thread))
-        self._connect_thread = Thread(target=self._try_to_connect)
+        self._connect_thread = Thread(target=self._try_to_connect,
+                                      args=[wait])
         self._connect_thread.setDaemon(True)
         self._connect_thread.start()
 
-    def _try_to_connect(self):
+    def _try_to_connect(self, wait=True):
         self._connected = False
         sleep_time = self._timeout / 10
         if self._socket is not None:
@@ -279,6 +280,8 @@ class SocketCom(object):
                 break
             except Exception:
                 self.log.debug('Fail to connect', exc_info=True)
+                if not wait:
+                    break
                 time.sleep(sleep_time)
 
     def _send_data(self, raw_data, wait_answer=True, size=8192):

--- a/pyIcePAP/controller.py
+++ b/pyIcePAP/controller.py
@@ -49,10 +49,20 @@ class IcePAPController(dict):
 
     def __init__(self, comm_type, *args, **kwargs):
         dict.__init__(self)
-        self._comm = IcePAPCommunication(comm_type, *args, **kwargs)
-        self._aliases = {}
         log_name = '{0}.IcePAPController'.format(__name__)
         self.log = logging.getLogger(log_name)
+        self._comm = IcePAPCommunication(comm_type, *args, **kwargs)
+        # TODO: Find solution for serial communication.
+        if not self.connected:
+            if 'host' in kwargs:
+                host = kwargs['host']
+            else:
+                host = args[0]
+            error_msg = 'Can not connect to {0}. Check if the IcePAP ' \
+                        'is ON.'.format(host)
+            self.log.error(error_msg)
+            raise RuntimeError(error_msg)
+        self._aliases = {}
         ver = self.ver.driver[0]
         if ver >= 3:
             self._new_api = True


### PR DESCRIPTION
We found this problem on Circe with the Pool controller. By default the connection thread waits until the IcePAP is connected. If the IcePAP is OFF, the Pool does not finish the starting procedure. 