### PR TITLE
Add protection on firmware version reading

### DIFF
--- a/pyIcePAP/fwversion.py
+++ b/pyIcePAP/fwversion.py
@@ -79,7 +79,7 @@ def key_error(fn):
 class FirmwareVersion(dict):
     """
     Class to manage the different version numbers for the different components
-    of the IcePAP system.
+    of the IcePAP system. A negative value means an error on the data.
     """
     def __init__(self, data, is_axis=False):
         super(FirmwareVersion, self).__init__()
@@ -89,7 +89,10 @@ class FirmwareVersion(dict):
             length = len(line.split(line.lstrip())[0])
             # print 'length = %s' % l
             component = v[0].strip()
-            value = float(v[1].strip())
+            try:
+                value = float(v[1].strip())
+            except Exception:
+                value = -1.0
             # print component, value
             # manage date
             when = ''


### PR DESCRIPTION
Old version can returns wrong values on the data:
 
```
In [7]: icom.send_cmd('0:?ver info')
DEBUG:RAW_DATA to send: '0:?ver info\r'
DEBUG:RAW_DATA read: '0:?VER $\r\nSYSTEM       :  1.22 : Tue Jun 29 12:39:54 2010\n   CONTROLLER:  1.22\r\n      DSP    :  2.84 : Mon Jun 28 15:27:36 2010\n      FPGA   :  0.03 : Tue Jun 19 16:54:00 2007\n      PCB    :  0.07\r\n      MCPU   : \r\n   DRIVER    :  1.22\r\n$'
Out[7]: 
['SYSTEM       :  1.22 : Tue Jun 29 12:39:54 2010',
 '   CONTROLLER:  1.22',
 '      DSP    :  2.84 : Mon Jun 28 15:27:36 2010',
 '      FPGA   :  0.03 : Tue Jun 19 16:54:00 2007',
 '      PCB    :  0.07',
 '      MCPU   : ',
 '   DRIVER    :  1.22']

```
In this case there is not value for the MCPU