### PR TITLE
Reduce deprecation warning frequency

### DIFF
--- a/pyIcePAP/legacy/icepapdef.py
+++ b/pyIcePAP/legacy/icepapdef.py
@@ -300,7 +300,7 @@ def deprecated(alt=None):
     def _deprecated(f):
         from inspect import isclass, isfunction
         import warnings
-        warnings.simplefilter("always")
+        warnings.simplefilter("once")
         # Force warnings.warn() to omit the source code line in the message
         formatwarning_orig = warnings.formatwarning
         warnings.formatwarning = lambda msg, cat, fname, lineno, line=None: \


### PR DESCRIPTION
Set the deprecation warning frequency to one, it only shows the message the first time of use of the method/class.