### PR TITLE
Remove erroneous feature.

### DIFF
--- a/pyIcePAP/controller.py
+++ b/pyIcePAP/controller.py
@@ -81,9 +81,6 @@ class IcePAPController(dict):
             item = self._aliases[item]
         return dict.__getitem__(self, item)
 
-    def __iter__(self):
-        return iter([dict.__getitem__(self, item) for item in self.keys()])
-
     def _create_axes(self):
         # Take the list of racks present in the system
         # IcePAP user manual pag. 137


### PR DESCRIPTION
Remove the iterator behaviour implemented to be compatible with IcepapCMS and heritage theory.

See https://github.com/ALBA-Synchrotron/IcepapCMS/issues/16