### PR TITLE
Signal config parameters

### DIFF
--- a/icepap/axis.py
+++ b/icepap/axis.py
@@ -1241,7 +1241,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'INFOA {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'INFOA {0}'.format(cfg)
         self.send_cmd(cmd)
 
     @property
@@ -1260,7 +1261,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'INFOB {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'INFOB {0}'.format(cfg)
         self.send_cmd(cmd)
 
     @property
@@ -1279,7 +1281,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'INFOC {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'INFOC {0}'.format(cfg)
         self.send_cmd(cmd)
 
     @property
@@ -1298,7 +1301,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'OUTPOS {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'OUTPOS {0}'.format(cfg)
         self.send_cmd(cmd)
 
     @property
@@ -1317,7 +1321,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'OUTPAUX {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'OUTPAUX {0}'.format(cfg)
         self.send_cmd(cmd)
 
     @property
@@ -1336,7 +1341,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'SYNCPOS {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'SYNCPOS {0}'.format(cfg)
         self.send_cmd(cmd)
 
     @property
@@ -1355,7 +1361,8 @@ class IcePAPAxis:
 
         :param cfg: (str, str) [Signal, Polarity]
         """
-        cmd = 'SYNCAUX {0} {1}'.format(*cfg)
+        cfg = ' '.join(cfg)
+        cmd = 'SYNCAUX {0}'.format(cfg)
         self.send_cmd(cmd)
 
 # ------------------------------------------------------------------------

--- a/tests/patch_socket.py
+++ b/tests/patch_socket.py
@@ -35,7 +35,11 @@ def patch_socket(mock):
                   enc_axis=100, velocity=100, velocity_max=3000,
                   velocity_min=2, velocity_default=50, acctime=0.1,
                   acctime_default=0.01, acctime_steps=30, pcloop='ON',
-                  indexer='INTERNAL'),
+                  indexer='INTERNAL',
+                  infoa='HIGH NORMAL', infob='HIGH NORMAL',
+                  infoc='HIGH INVERTED', outpos='MOTOR NORMAL',
+                  outpaux='LOW NORMAL', syncpos='AXIS NORMAL',
+                  syncaux='ENABLED NORMAL'),
         '5': dict(addr='5', name='tth', pos_axis=-3, fpos_axis=-3,
                   status='0x00205013', fstatus='0x00205013', power='ON'),
         '151': dict(addr='151', name='chi', pos_axis=-1000, fpos_axis=-1000,
@@ -96,9 +100,16 @@ def patch_socket(mock):
 
     def set_axis(cmd):
         axis, cmd = cmd.split(':', 1)
-        register, value = cmd.split()
+        register, value = cmd.split(' ', 1)
+        register = register.lower()
+        if register in ['infoa', 'infob', 'infoc', 'outpos', 'outpaux',
+                        'syncpos', 'syncaux']:
+            value = value.split()
+            if len(value) == 1:
+                value.append('NORMAL')
+            value = ' '.join(value)
         if axis in axes:
-            axes[axis][register.lower()] = value
+            axes[axis][register] = value
             msg = 'OK'
         else:
             msg = 'ERROR Board is not present in the system'
@@ -135,15 +146,16 @@ def patch_socket(mock):
         cmd = cmd.upper().strip()
 
         # Position registers
-        cmd = cmd.replace('POS AXIS', 'POS_AXIS')
-        cmd = cmd.replace('POS SHFTENC', 'POS_AXIS')
-        cmd = cmd.replace('POS TGTENC', 'POS_AXIS')
-        cmd = cmd.replace('POS CTRLENC', 'POS_AXIS')
-        cmd = cmd.replace('POS ENCIN', 'POS_AXIS')
-        cmd = cmd.replace('POS INPOS', 'POS_AXIS')
-        cmd = cmd.replace('POS ABSENC', 'POS_AXIS')
-        cmd = cmd.replace('POS MOTOR', 'POS_AXIS')
-        cmd = cmd.replace('POS SYNC', 'POS_AXIS')
+        if 'OUTPOS' not in cmd and 'SYNCPOS' not in cmd:
+            cmd = cmd.replace('POS AXIS', 'POS_AXIS')
+            cmd = cmd.replace('POS SHFTENC', 'POS_AXIS')
+            cmd = cmd.replace('POS TGTENC', 'POS_AXIS')
+            cmd = cmd.replace('POS CTRLENC', 'POS_AXIS')
+            cmd = cmd.replace('POS ENCIN', 'POS_AXIS')
+            cmd = cmd.replace('POS INPOS', 'POS_AXIS')
+            cmd = cmd.replace('POS ABSENC', 'POS_AXIS')
+            cmd = cmd.replace('POS MOTOR', 'POS_AXIS')
+            cmd = cmd.replace('POS SYNC', 'POS_AXIS')
 
         # Encoder registers
         cmd = cmd.replace('ENC AXIS', 'ENC_AXIS')

--- a/tests/test_icepap.py
+++ b/tests/test_icepap.py
@@ -138,6 +138,21 @@ def confirm_m1(m1):
 
     assert m1.indexer == 'INTERNAL'
 
+    m1.infoa = ['LOW']
+    assert set(m1.infoa) == {'LOW', 'NORMAL'}
+    m1.infob = ['HIGH', 'NORMAL']
+    assert set(m1.infob) == {'HIGH', 'NORMAL'}
+    m1.infoc = ['LOW']
+    assert set(m1.infoc) == {'LOW', 'NORMAL'}
+    m1.outpaux = ['HIGH', 'NORMAL']
+    assert set(m1.outpaux) == {'HIGH', 'NORMAL'}
+    m1.outpos = ['MOTOR']
+    assert set(m1.outpos) == {'MOTOR', 'NORMAL'}
+    m1.syncpos = ['AXIS']
+    assert set(m1.syncpos) == {'AXIS', 'NORMAL'}
+    m1.syncaux = ['ENABLED', 'INVERTED']
+    assert set(m1.syncaux) == {'ENABLED', 'INVERTED'}
+
 
 def ice_auto_axes(f):
     """A helper which provides parametrized auto_axes version of icepap"""


### PR DESCRIPTION
The IcePAP commands: infoX, outpos, outpaux, syncpos and syncaux have the polarity as an optional parameter. In case do not pass it, the IcePAP uses NORMAL polarity as default value. 

This PR implements this behavior on the library layer. 