### PR TITLE
Allow to read only system or driver version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.6.x] 
 ### Added
  - Add fver property to read only the driver and the system version instead 
-   of reading all modules versions
+   of reading all modules versions.
+ - Allow to use IcePAPAxis object as parameter of IcePAPController commands. 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!--## [Unreleased] -->
 <!--### Added -->
 
-## [3.5.x] 
+## [3.6.x] 
+### Added
+ - Add fver property to read only the driver and the system version instead 
+   of reading all modules versions
+
+### Removed
+
+### Fixed
+- Change TCP class logger name to use logging filtering on IcepapCMS
+
+## [3.5.1] 
 ### Added
  - Add CLI application
 
@@ -202,7 +212,8 @@ Last release of pyIcePAP library (old API).
 
 [keepachangelog.com]: http://keepachangelog.com
 [Unreleased]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/2.3.2...HEAD
-[3.5.x]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/3.4.1...HEAD
+[3.6.x]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/3.5.1...HEAD
+[3.5.1]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/3.4.1...3.5.1
 [3.4.1]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/3.3.0...3.4.1
 [3.3.0]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/3.2.2...3.3.0
 [3.2.2]: https://github.com/ALBA-Synchrotron/pyIcePAP/compare/3.1.0...3.2.2

--- a/icepap/axis.py
+++ b/icepap/axis.py
@@ -485,6 +485,17 @@ class IcePAPAxis:
         return FirmwareVersion(ans, True)
 
     @property
+    def fver(self):
+        """
+        Get the only driver version 'axis:?VER'
+        (IcePAP user manual pag. 144).
+
+        :return: float
+        """
+        ans = self.send_cmd('?VER')[0]
+        return float(ans)
+
+    @property
     def name(self):
         """
         Get the axis name (Icepap user manual pag. 95).

--- a/icepap/controller.py
+++ b/icepap/controller.py
@@ -183,6 +183,17 @@ class IcePAPController:
         return FirmwareVersion(ans)
 
     @property
+    def fver(self):
+        """
+        Get the only system version '?VER'
+        (IcePAP user manual pag. 144).
+
+        :return: float
+        """
+        ans = self.send_cmd('?VER')[0]
+        return float(ans)
+
+    @property
     def ver_saved(self):
         """
         Returns the firmware version stored in the master flash memory.

--- a/icepap/controller.py
+++ b/icepap/controller.py
@@ -106,10 +106,10 @@ class IcePAPController:
     def _alias2axisstr(self, alias):
         """
         Method to get the axis motor number. The input can be: string or a
-        number or a list with combination of strings and numbers. The result
-        depends of the number of inputs.
+        number or IcePAPAxis or a list with combination of strings and
+        numbers. The result depends of the number of inputs.
 
-        :param alias: str or int or [str, int, ...]
+        :param alias: IcePAPAxis or str or int or [str, int, IcePAPAxis, ...]
 
         :return: str
         """
@@ -117,6 +117,8 @@ class IcePAPController:
             result = str(alias)
         elif isinstance(alias, str):
             result = str(self._get_axis_for_alias(alias))
+        elif isinstance(alias, IcePAPAxis):
+            result = str(alias.axis)
         elif isinstance(alias, list):
             result = []
             for i in alias:

--- a/icepap/tcp.py
+++ b/icepap/tcp.py
@@ -225,7 +225,8 @@ class TCP:
         self.timeout = timeout
         self.connection_counter = 0
         self._sock = None
-        self._log = logging.getLogger("icepap.TCP({})".format(host))
+        logger_name = "{}.TCP.{}".format(__name__, host)
+        self._log = logging.getLogger(logger_name)
 
     def connected(self):
         return self._sock is not None and self._sock.state() is OPEN


### PR DESCRIPTION
Add property to read only the system/driver version instead of read the version of all modules. It takes less time and reduce the load time on IcepapCMS