### PR TITLE
Icepapctl patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+  - icepapctl sendall allowed only one parameter and is not protected when 
+    the character ':' is used. 
+  - Shows PCB value for controller and drivers and IO value for drivers 
 
 ### Changed
    - Sendall responses are tabulated

--- a/icepap/cli/cli.py
+++ b/icepap/cli/cli.py
@@ -308,10 +308,16 @@ def send(ctx, cmd):
 
 @cli.command()
 @click.pass_context
-@click.argument("cmd", type=str, required=True)
+@click.argument("cmd", nargs=-1, type=str, required=True)
 def sendall(ctx, cmd):
-    """ Send raw command to selected axes with option --axes """
+    """
+    Send raw command to selected axes with option --axes. The ':' character
+    will be removed from the command
+    """
     axes = ctx.obj['axes']
+    cmd = ' '.join(cmd)
+    if ':' in cmd:
+        cmd = cmd.split(':')[1]
     for axis in axes:
         try:
             output = axis.send_cmd(cmd)

--- a/icepap/cli/tables.py
+++ b/icepap/cli/tables.py
@@ -199,7 +199,7 @@ def VersionTable(group, info=True,
             table.rows.append(row)
     else:
         print('Reading...')
-        header = "Axis", "SYSTEM", "DRIVER", "DSP", "FPGA"
+        header = "Axis", "SYSTEM", "DRIVER", "DSP", "FPGA", "PCB", "IO"
         for motor in group.motors:
             axis_ver = motor.ver
             diff = False
@@ -207,7 +207,8 @@ def VersionTable(group, info=True,
                 diff = True
 
             data = [motor.addr, axis_ver.system[0], axis_ver.driver[0],
-                    axis_ver.driver_dsp[0], axis_ver.driver_fpga[0]]
+                    axis_ver.driver_dsp[0], axis_ver.driver_fpga[0],
+                    axis_ver.driver_pcb[0], axis_ver.driver_io[0]]
 
             if diff:
                 color = ERROR_COLOR

--- a/icepap/fwversion.py
+++ b/icepap/fwversion.py
@@ -122,6 +122,8 @@ class FirmwareVersion(dict):
                                                   str(self.ctrl_dsp))
             msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'FPGA',
                                                   str(self.ctrl_fpga))
+            msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'PCB',
+                                                  str(self.ctrl_pcb))
             msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'MCPU0',
                                                   str(self.ctrl_mcpu0))
             msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'MCPU1',
@@ -135,6 +137,10 @@ class FirmwareVersion(dict):
                                                   str(self.driver_dsp))
             msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'FPGA',
                                                   str(self.driver_fpga))
+            msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'PCB',
+                                                  str(self.driver_pcb))
+            msg += '{0:}{1:<9s}:{2:>5s}\n'.format(sublevel, 'IO',
+                                                  str(self.driver_io))
         return msg
 
     def is_supported(self):
@@ -238,6 +244,15 @@ class FirmwareVersion(dict):
 
     @property
     @key_error
+    def ctrl_pcb(self):
+        """
+        Returns Controller FPGA version.
+
+        :return: str
+        """
+        return self['SYSTEM']['CONTROLLER']['PCB']
+    @property
+    @key_error
     def ctrl_mcpu0(self):
         """
         Returns MCPU0 version.
@@ -305,3 +320,13 @@ class FirmwareVersion(dict):
         :return: (float, str)
         """
         return self['SYSTEM']['DRIVER']['PCB']
+
+    @property
+    @key_error
+    def driver_io(self):
+        """
+        Returns driver PCB version.
+
+        :return: (float, str)
+        """
+        return self['SYSTEM']['DRIVER']['IO']


### PR DESCRIPTION
Allow to send more parameter on the sendall command and remove the character ":" 
Show PCB and IO version for controller and drivers