### PR TITLE
Measured position

### DIFF
--- a/icepap/axis.py
+++ b/icepap/axis.py
@@ -713,7 +713,6 @@ class IcePAPAxis:
         """
         self.set_pos('AXIS', value)
 
-
     @property
     def pos_measure(self):
         """
@@ -893,6 +892,24 @@ class IcePAPAxis:
         :param value: int
         """
         self.set_enc('AXIS', value)
+
+    @property
+    def enc_measure(self):
+        """
+        Read the measure register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self.get_enc('MEASURE')
+
+    @enc_measure.setter
+    def enc_measure(self, value):
+        """
+        Set the measure register (IcePAP user manual pag. 108).
+
+        :param value: int
+        """
+        self.set_enc('MEASURE', value)
 
     @property
     def enc_shftenc(self):

--- a/icepap/axis.py
+++ b/icepap/axis.py
@@ -713,6 +713,25 @@ class IcePAPAxis:
         """
         self.set_pos('AXIS', value)
 
+
+    @property
+    def pos_measure(self):
+        """
+        Read the measure register (IcePAP user manual pag. 108).
+
+        :return: int
+        """
+        return self.get_pos('MEASURE')
+
+    @pos_measure.setter
+    def pos_measure(self, value):
+        """
+        Set the measure register (IcePAP user manual pag. 108).
+
+        :param value: int
+        """
+        self.set_pos('MEASURE', value)
+
     @property
     def pos_shftenc(self):
         """


### PR DESCRIPTION
## Description

Add `IcePAPAxis` properties for measured position registers.

This is useful when the register/functional encoder for the measured position is unknown/variable